### PR TITLE
call into generix axpy! intead of the BLAS specific one

### DIFF
--- a/src/arpack-blas-qr.jl
+++ b/src/arpack-blas-qr.jl
@@ -377,7 +377,7 @@ function _dger!(alpha, x::AbstractVecOrMat, y::AbstractVecOrMat, A::AbstractMatr
   for j=1:n
     if y[j] != 0 
       temp = alpha*conj(y[j])
-      LinearAlgebra.BLAS.axpy!(temp, x, @view(A[:,j]))
+      LinearAlgebra.axpy!(temp, x, @view(A[:,j]))
       #for i=1:m
         #A[i,j] += x[i]*temp
         #A[i,j] = muladd(x[i],temp,A[i,j])

--- a/src/dsapps.jl
+++ b/src/dsapps.jl
@@ -850,7 +850,7 @@ function dsapps!(
   _dscal!(Q[kplusp,kev], @view(resid[1:n]))
   if H[kev+1,1] > 0
     # axpy!(a, X, Y), Overwrite Y with X*a + Y,
-    LinearAlgebra.BLAS.axpy!(H[kev+1,1], @view(V[1:n,kev+1]), @view(resid[1:n]))
+    LinearAlgebra.axpy!(H[kev+1,1], @view(V[1:n,kev+1]), @view(resid[1:n]))
   end 
 
   if msglvl > 0 
@@ -867,4 +867,3 @@ function dsapps!(
   @jl_update_time(tapps, t0)
   return nothing
 end 
-

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -392,7 +392,7 @@ function svd_residuals!(r, A, U, s, V)
     else
       mul!(av, A, @view(V[:,i]))
     end 
-    LinearAlgebra.BLAS.axpy!(-s[i], @view(U[:,i]), av)
+    LinearAlgebra.axpy!(-s[i], @view(U[:,i]), av)
     r[i] = norm(av)
   end 
   return r


### PR DESCRIPTION
`BLAS.axpy!` and `LinearAlgebra.axpy!` (the generic version) were separated in https://github.com/JuliaLang/julia/pull/44758 since calls to `BLAS.axpy!` did not always call into BLAS. This made this package break since it is calling `BLAS.axpy!` with element types that BLAS do not support. Just calling `axpy!` fixes this.